### PR TITLE
Add Mark Duplicates feature (Issue #3)

### DIFF
--- a/src/pages/ListCleaner.css
+++ b/src/pages/ListCleaner.css
@@ -131,9 +131,45 @@
   margin-top: 2rem;
 }
 
+.marked-duplicates-display {
+  margin-top: 2rem;
+  margin-bottom: 2rem;
+}
+
+.marked-lines-container {
+  border: 2px solid #bdc3c7;
+  border-radius: 4px;
+  background-color: white;
+  max-height: 400px;
+  overflow-y: auto;
+  padding: 0.5rem;
+  font-family: 'Courier New', monospace;
+}
+
+.marked-line {
+  padding: 0.5rem 0.75rem;
+  margin: 0.25rem 0;
+  border-radius: 4px;
+  border-left: 4px solid transparent;
+  transition: background-color 0.2s;
+  word-break: break-word;
+  line-height: 1.5;
+}
+
+.marked-line.duplicate-line {
+  border-left-width: 4px;
+  border-left-style: solid;
+  font-weight: 500;
+}
+
+.marked-line:not(.duplicate-line) {
+  color: #7f8c8d;
+}
+
 @media (min-width: 768px) {
   .listcleaner-input-section,
-  .listcleaner-output-section {
+  .listcleaner-output-section,
+  .marked-duplicates-display {
     max-width: 800px;
     margin-left: auto;
     margin-right: auto;


### PR DESCRIPTION
- Add 'Mark Duplicates' button to ListCleaner page
- Implement color marking for duplicate lines
- Each duplicate group gets a unique color from a palette
- Display marked duplicates in a scrollable container
- Marking resets when input changes
- Remove Duplicates button still works as before